### PR TITLE
refactor: validate environment variables

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 	"scripts": {
 		"dev": "bun --watch ./src/index.ts",
 		"prod": "NODE_ENV=production bun src/index.ts",
-		"format": "biome format",
+		"format": "biome format --write ./src",
 		"lint": "biome check ./src",
 		"migrate": "bun run migrate:generate && bun run migrate:execute",
 		"migrate:generate": "drizzle-kit generate:sqlite",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "entities-decode": "^2.0.0",
     "erlpack": "^0.1.4",
     "utf-8-validate": "^6.0.3",
+    "valibot": "^0.25.0",
     "zlib-sync": "^0.1.9"
   },
   "scripts": {

--- a/src/commands/mdn.ts
+++ b/src/commands/mdn.ts
@@ -43,16 +43,6 @@ const Info: Command = {
 	},
 
 	async run(interaction) {
-		if (!CAN_QUERY) {
-			interaction
-				.reply({
-					ephemeral: true,
-					content: "Sorry! This command is unavailable for the moment.",
-				})
-				.catch(console.error);
-			return;
-		}
-
 		const query = interaction.options.getString("query", true);
 		let url: string;
 		if (query.startsWith("docs/")) url = MDN_URL + query;
@@ -97,16 +87,9 @@ const Info: Command = {
 };
 export default Info;
 
-const BASE_URL =
-	process.env.CSE_KEY && process.env.CSE_CSX
-		? `https://www.googleapis.com/customsearch/v1/siterestrict?key=${process.env.CSE_KEY}&cx=${process.env.CSE_CSX}`
-		: "";
-
-const CAN_QUERY = !!BASE_URL;
+const BASE_URL = `https://www.googleapis.com/customsearch/v1/siterestrict?key=${process.env.CSE_KEY}&cx=${process.env.CSE_CSX}`
 
 function search(term: string, num = 10) {
-	if (!CAN_QUERY)
-		throw new Error("Cannot query Google CSE, key or CSX missing.");
 	if (!Number.isInteger(num) || num < 1 || num > 10)
 		throw new RangeError(
 			`The number of results must be an integer between 1 and 10, inclusive (got ${num}).`,

--- a/src/commands/mdn.ts
+++ b/src/commands/mdn.ts
@@ -89,7 +89,7 @@ const Info: Command = {
 };
 export default Info;
 
-const BASE_URL = `https://www.googleapis.com/customsearch/v1/siterestrict?key=${process.env.CSE_KEY}&cx=${process.env.CSE_CSX}`
+const BASE_URL = `https://www.googleapis.com/customsearch/v1/siterestrict?key=${process.env.CSE_KEY}&cx=${process.env.CSE_CSX}`;
 
 function search(term: string, num = 10) {
 	if (!Number.isInteger(num) || num < 1 || num > 10)

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,11 +8,11 @@ import {
 } from "discord.js";
 import { join } from "node:path";
 import { readdir } from "node:fs/promises";
-import {exit} from "node:process";
+import { exit } from "node:process";
 import { castArray } from "./utils.ts";
 import type { Listener } from "./types/listener.ts";
 import env from "./types/env.ts";
-import {safeParse} from "valibot"
+import { safeParse } from "valibot";
 const client = new Client({
 	intents: [
 		GatewayIntentBits.Guilds,
@@ -22,14 +22,28 @@ const client = new Client({
 	],
 });
 
-const parsedEnv = safeParse(env, Object.fromEntries(Object.entries(process.env).filter(([k])=>k in env.entries) /* Do not allow the program to access values not specified in the schema*/))
+const parsedEnv = safeParse(
+	env,
+	Object.fromEntries(
+		Object.entries(process.env).filter(
+			([k]) => k in env.entries,
+		) /* Do not allow the program to access values not specified in the schema*/,
+	),
+);
 if (!parsedEnv.success) {
-	console.error(`Issues loading environment variables: \n-----------\n${parsedEnv.issues.map((issue)=>`Variable: ${issue?.path?.[0].key}\nInput: ${issue.input}\nError: ${issue.message}\n-----------`).join('\n')}`)
-	exit(1)
+	console.error(
+		`Issues loading environment variables: \n-----------\n${parsedEnv.issues
+			.map(
+				(issue) =>
+					`Variable: ${issue?.path?.[0].key}\nInput: ${issue.input}\nError: ${issue.message}\n-----------`,
+			)
+			.join("\n")}`,
+	);
+	exit(1);
 }
 
 // @ts-expect-error default process.env signature only includes strings
-process.env = parsedEnv.output
+process.env = parsedEnv.output;
 client.once(Events.ClientReady, async (bot) => {
 	try {
 		await loadCommands(client, {

--- a/src/scraper.ts
+++ b/src/scraper.ts
@@ -7,18 +7,7 @@ export type CheerioNode = {
 	attribs: { [attr: string]: string };
 };
 
-if (process.env.SCRAPE_CACHE) {
-	if (!Number.isInteger(+process.env.SCRAPE_CACHE))
-		throw new TypeError(
-			"Environment variable SCRAPE_CACHE should be an integer",
-		);
-	if (+process.env.SCRAPE_CACHE < 0)
-		throw new RangeError(
-			"Environment variable SCRAPE_CACHE should be 0 or positive",
-		);
-}
-
-const CACHE_DURATION = +(process.env.SCRAPE_CACHE || 1) * 3600_000;
+const CACHE_DURATION = (process.env.SCRAPE_CACHE || 1)  * 3600_000;
 const cache = new Map<string, { fetchDate: number; crawler: CheerioAPI }>();
 
 export default async function scrape(url: string, skipCache = false) {

--- a/src/scraper.ts
+++ b/src/scraper.ts
@@ -7,7 +7,7 @@ export type CheerioNode = {
 	attribs: { [attr: string]: string };
 };
 
-const CACHE_DURATION = (process.env.SCRAPE_CACHE || 1)  * 3600_000;
+const CACHE_DURATION = (process.env.SCRAPE_CACHE || 1) * 3600_000;
 const cache = new Map<string, { fetchDate: number; crawler: CheerioAPI }>();
 
 export default async function scrape(url: string, skipCache = false) {

--- a/src/types/env.ts
+++ b/src/types/env.ts
@@ -1,0 +1,23 @@
+import { number, object, string, minValue, coerce, boolean, optional, picklist, transform } from "valibot";
+
+const env = object({
+	TOKEN: string(),
+	GUILD: string(),
+	CSE_KEY: string(),
+	CSE_CSX: string(),
+	SCRAPE_CACHE: optional(coerce(number([minValue(0,"Must not be negative")]), Number)),
+	ORM_DEBUG: optional(transform(picklist(["true","false"],"Must be true or false"),(input)=>input==="true")),
+	NODE_ENV: optional(picklist(["production","development"])),
+	TZ: optional(string())
+});
+declare module "bun" {
+	interface Env {
+		TOKEN: string;
+		GUILD: string;
+		CSE_KEY: string;
+		CSE_CSX: string;
+		SCRAPE_CACHE?: number;
+		ORM_DEBUG?: boolean;
+	}
+}
+export default env;

--- a/src/types/env.ts
+++ b/src/types/env.ts
@@ -1,14 +1,30 @@
-import { number, object, string, minValue, coerce, boolean, optional, picklist, transform } from "valibot";
+import {
+	number,
+	object,
+	string,
+	minValue,
+	coerce,
+	optional,
+	picklist,
+	transform,
+} from "valibot";
 
 const env = object({
 	TOKEN: string(),
 	GUILD: string(),
 	CSE_KEY: string(),
 	CSE_CSX: string(),
-	SCRAPE_CACHE: optional(coerce(number([minValue(0,"Must not be negative")]), Number)),
-	ORM_DEBUG: optional(transform(picklist(["true","false"],"Must be true or false"),(input)=>input==="true")),
-	NODE_ENV: optional(picklist(["production","development"])),
-	TZ: optional(string())
+	SCRAPE_CACHE: optional(
+		coerce(number([minValue(0, "Must not be negative")]), Number),
+	),
+	ORM_DEBUG: optional(
+		transform(
+			picklist(["true", "false"], "Must be true or false"),
+			(input) => input === "true",
+		),
+	),
+	NODE_ENV: optional(picklist(["production", "development"])),
+	TZ: optional(string()),
 });
 declare module "bun" {
 	interface Env {


### PR DESCRIPTION
This PR uses valibot to  validate environment variables, creating more stringent restrictions to prevent unexpected behavior and removing the need for type guards elsewhere. This also adds types for the env variables.