### PR TITLE
fix schemas/config.ts syntax

### DIFF
--- a/src/schemas/config.ts
+++ b/src/schemas/config.ts
@@ -20,8 +20,8 @@ export const Config = sqliteTable("guildConfig", {
 
 	suggestionChannel: text("suggestionChannel"),
 	suggestionManagerRole: text("suggestionManagerRole"),
-	suggestionUpvoteEmoji: text("suggestionUpvoteEmoji",).default('👍'),
-	suggestionDownvoteEmoji: text("suggestionDownvoteEmoji").default('👎'),
+	suggestionUpvoteEmoji: text("suggestionUpvoteEmoji").default("👍"),
+	suggestionDownvoteEmoji: text("suggestionDownvoteEmoji").default("👎"),
 });
 
 export type ConfigSelect = InferSelectModel<typeof Config>;


### PR DESCRIPTION
Removes a stray comma and a random use of single quotes
It now complies with Biome