### PR TITLE
chore: replace deprecated 'ephemeral' option with a flag

### DIFF
--- a/src/commands/delete-and-warn.ts
+++ b/src/commands/delete-and-warn.ts
@@ -17,18 +17,18 @@ const DeleteAndWarn: MessageCommand = {
 		const { channel, targetMessage } = interaction;
 		if (!channel)
 			return interaction.reply({
-				ephemeral: true,
+				flags: "Ephemeral",
 				content: "Error: could not fetch the channel",
 			});
 		if (channel.isDMBased())
 			return interaction.reply({
-				ephemeral: true,
+				flags: "Ephemeral",
 				content: "Cannot use this command in DMs",
 			});
 
 		if (!targetMessage.deletable) {
 			return interaction.reply({
-				ephemeral: true,
+				flags: "Ephemeral",
 				content:
 					"I do not have the permission to delete messages in this channel.",
 			});

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -14,7 +14,7 @@ const Info: Command = {
 		if (!interaction.guild) {
 			interaction.reply({
 				content: "Run this command in a server to get server info",
-				ephemeral: true,
+				flags: "Ephemeral",
 			});
 			return;
 		}

--- a/src/commands/purge.ts
+++ b/src/commands/purge.ts
@@ -28,7 +28,7 @@ const Purge: Command = {
 		const { channel } = interaction;
 
 		function reply(content: string) {
-			return interaction.reply({ ephemeral: true, content });
+			return interaction.reply({ flags: "Ephemeral", content });
 		}
 
 		if (!channel) {

--- a/src/listeners/delete-and-warn.ts
+++ b/src/listeners/delete-and-warn.ts
@@ -15,9 +15,8 @@ export default [
 			const [targetId, messageId] = interaction.customId.split("_", 2);
 			const target = await interaction.guild.members.fetch(targetId);
 			const reason = interaction.fields.getField("deletionReason").value;
-			const targetMessage = await interaction.channel?.messages.fetch(
-				messageId,
-			);
+			const targetMessage =
+				await interaction.channel?.messages.fetch(messageId);
 			targetMessage?.delete().catch(console.error);
 			if (target.moderatable) {
 				const timeout = parseTime(interaction.fields.getField("timeout").value);
@@ -30,7 +29,7 @@ export default [
 				.then(() => {
 					interaction
 						.reply({
-							ephemeral: true,
+							flags: "Ephemeral",
 							content: "Reason sent.",
 						})
 						.catch(console.error);
@@ -38,7 +37,7 @@ export default [
 				.catch(() => {
 					interaction
 						.reply({
-							ephemeral: true,
+							flags: "Ephemeral",
 							content: `The reason could not be sent to ${target}; they proabably blocked me or disabled DMs from server members.\n\`\`\`${reason}\`\`\``,
 						})
 						.catch(console.error);

--- a/src/listeners/suggestion-interaction.ts
+++ b/src/listeners/suggestion-interaction.ts
@@ -31,7 +31,7 @@ import { Suggestion } from "../structures/suggestion.ts";
 const MODAL_ID = "suggestion-modal";
 const MODAL_INPUT_ID = "suggestion-reason";
 
-export default ([
+export default [
 	// Handle status update interaction
 	{
 		event: "interactionCreate",
@@ -56,7 +56,7 @@ export default ([
 					content: `You're missing the manager role and ${inlineCode(
 						"ManageGuild",
 					)} permission`,
-					ephemeral: true,
+					flags: "Ephemeral",
 				});
 			}
 
@@ -66,7 +66,7 @@ export default ([
 			) {
 				return interaction.reply({
 					content: `You're missing the ${inlineCode("ManageGuild")} permission`,
-					ephemeral: true,
+					flags: "Ephemeral",
 				});
 			}
 
@@ -124,7 +124,7 @@ export default ([
 					"this suggestion",
 					interaction.message.url,
 				)} to ${inlineCode(statusString.toLowerCase())}`,
-				ephemeral: true,
+				flags: "Ephemeral",
 			});
 		},
 	},
@@ -154,7 +154,7 @@ export default ([
 						"this",
 						interaction.message.url,
 					)} suggestion`,
-					ephemeral: true,
+					flags: "Ephemeral",
 				});
 			} else {
 				await suggestion.downvote(interaction.user.id, config);
@@ -163,9 +163,9 @@ export default ([
 						"this",
 						interaction.message.url,
 					)} suggestion`,
-					ephemeral: true,
+					flags: "Ephemeral",
 				});
 			}
 		},
 	},
-] as Listener[]);
+] as Listener[];


### PR DESCRIPTION
The `ephemeral` option in `CommandInteraction#reply` has been [deprecated](https://github.com/discordjs/discord.js/releases/tag/14.17.0), and should be replaced with the `Ephemeral` flag.
This commit does just that.