### PR TITLE
ref: replace "Ephemeral" with a an enum value

### DIFF
--- a/src/commands/delete-and-warn.ts
+++ b/src/commands/delete-and-warn.ts
@@ -2,6 +2,7 @@ import {
 	PermissionFlagsBits,
 	ApplicationCommandType,
 	TextInputStyle,
+	MessageFlags,
 } from "discord.js";
 const { ManageMessages, ModerateMembers } = PermissionFlagsBits;
 import { modalInput } from "../components.ts";
@@ -17,18 +18,18 @@ const DeleteAndWarn: MessageCommand = {
 		const { channel, targetMessage } = interaction;
 		if (!channel)
 			return interaction.reply({
-				flags: "Ephemeral",
+				flags: MessageFlags.Ephemeral,
 				content: "Error: could not fetch the channel",
 			});
 		if (channel.isDMBased())
 			return interaction.reply({
-				flags: "Ephemeral",
+				flags: MessageFlags.Ephemeral,
 				content: "Cannot use this command in DMs",
 			});
 
 		if (!targetMessage.deletable) {
 			return interaction.reply({
-				flags: "Ephemeral",
+				flags: MessageFlags.Ephemeral,
 				content:
 					"I do not have the permission to delete messages in this channel.",
 			});

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -3,6 +3,7 @@ import {
 	type APIEmbed,
 	ApplicationCommandType,
 	channelMention,
+	MessageFlags,
 } from "discord.js";
 import type { Command } from "djs-fsrouter";
 
@@ -14,7 +15,7 @@ const Info: Command = {
 		if (!interaction.guild) {
 			interaction.reply({
 				content: "Run this command in a server to get server info",
-				flags: "Ephemeral",
+				flags: MessageFlags.Ephemeral,
 			});
 			return;
 		}

--- a/src/commands/purge.ts
+++ b/src/commands/purge.ts
@@ -1,4 +1,4 @@
-import { ApplicationCommandOptionType, PermissionFlagsBits } from "discord.js";
+import { ApplicationCommandOptionType, PermissionFlagsBits, MessageFlags } from "discord.js";
 const { ManageMessages } = PermissionFlagsBits;
 import type { Command } from "djs-fsrouter";
 
@@ -28,7 +28,7 @@ const Purge: Command = {
 		const { channel } = interaction;
 
 		function reply(content: string) {
-			return interaction.reply({ flags: "Ephemeral", content });
+			return interaction.reply({ flags: MessageFlags.Ephemeral, content });
 		}
 
 		if (!channel) {

--- a/src/listeners/delete-and-warn.ts
+++ b/src/listeners/delete-and-warn.ts
@@ -1,5 +1,6 @@
 import type { Listener } from "../types/listener.ts";
 import { customId } from "../commands/delete-and-warn.ts";
+import { MessageFlags } from "discord.js";
 
 export default [
 	{
@@ -29,7 +30,7 @@ export default [
 				.then(() => {
 					interaction
 						.reply({
-							flags: "Ephemeral",
+							flags: MessageFlags.Ephemeral,
 							content: "Reason sent.",
 						})
 						.catch(console.error);
@@ -37,7 +38,7 @@ export default [
 				.catch(() => {
 					interaction
 						.reply({
-							flags: "Ephemeral",
+							flags: MessageFlags.Ephemeral,
 							content: `The reason could not be sent to ${target}; they proabably blocked me or disabled DMs from server members.\n\`\`\`${reason}\`\`\``,
 						})
 						.catch(console.error);

--- a/src/listeners/suggestion-interaction.ts
+++ b/src/listeners/suggestion-interaction.ts
@@ -4,6 +4,7 @@ import {
 	ModalBuilder,
 	TextInputStyle,
 	inlineCode,
+	MessageFlags,
 } from "discord.js";
 import type { Listener } from "../types/listener.ts";
 import {
@@ -56,7 +57,7 @@ export default [
 					content: `You're missing the manager role and ${inlineCode(
 						"ManageGuild",
 					)} permission`,
-					flags: "Ephemeral",
+					flags: MessageFlags.Ephemeral,
 				});
 			}
 
@@ -66,7 +67,7 @@ export default [
 			) {
 				return interaction.reply({
 					content: `You're missing the ${inlineCode("ManageGuild")} permission`,
-					flags: "Ephemeral",
+					flags: MessageFlags.Ephemeral,
 				});
 			}
 
@@ -124,7 +125,7 @@ export default [
 					"this suggestion",
 					interaction.message.url,
 				)} to ${inlineCode(statusString.toLowerCase())}`,
-				flags: "Ephemeral",
+				flags: MessageFlags.Ephemeral,
 			});
 		},
 	},
@@ -154,7 +155,7 @@ export default [
 						"this",
 						interaction.message.url,
 					)} suggestion`,
-					flags: "Ephemeral",
+					flags: MessageFlags.Ephemeral,
 				});
 			} else {
 				await suggestion.downvote(interaction.user.id, config);
@@ -163,7 +164,7 @@ export default [
 						"this",
 						interaction.message.url,
 					)} suggestion`,
-					flags: "Ephemeral",
+					flags: MessageFlags.Ephemeral,
 				});
 			}
 		},


### PR DESCRIPTION
As requested in [this comment](https://github.com/Javascripters-Development/JavaScripters-Bot/pull/25#discussion_r1911770518), this PR replaces the message flag strings with enum values, for both consistency and future-proofing.